### PR TITLE
Ensure GitHub labels with version are reconciled

### DIFF
--- a/prow/external-plugins/verify-conformance-release/pkg/plugin/plugin.go
+++ b/prow/external-plugins/verify-conformance-release/pkg/plugin/plugin.go
@@ -297,6 +297,9 @@ func labelIsManaged(input string) bool {
 
 func labelIsVersionLabel(label, version string) bool {
 	for _, ml := range managedPRLabelTemplatesWithVersion {
+		if strings.Contains(label, strings.ReplaceAll(ml, "%v", "")) == true {
+			return true
+		}
 		if fmt.Sprintf(ml, version) == label {
 			return true
 		}


### PR DESCRIPTION
Adds check for if the label with version in it is found, not including the templating, similar to file label checks