### PR TITLE
Ensure sorting of missing tests in e2e.log response

### DIFF
--- a/prow/external-plugins/verify-conformance-release/pkg/suite/suite.go
+++ b/prow/external-plugins/verify-conformance-release/pkg/suite/suite.go
@@ -675,6 +675,7 @@ func (s *PRSuite) allRequiredTestsInE2eLogArePresent() error {
 		missingTests = append(missingTests, test)
 	}
 	if len(missingTests) > 0 {
+		sort.Strings(missingTests)
 		return common.SafeError(fmt.Errorf("there appears to be %v tests missing from e2e.log: \n    - %v", len(missingTests), strings.Join(missingTests, "\n    - ")))
 	}
 	return nil


### PR DESCRIPTION
There was an issue where emails were being spammed by the bot. The bot doesn't make comments until there's a difference.
The PR has issues concerning the missing e2e.log. In the past there was a similar issue with the _the following test(s) are missing_ response. This particular response isn't doing sorting, so I think it's likely the cause of the spam.

https://github.com/cncf/k8s-conformance/pull/1984#issuecomment-1147488504