### PR TITLE
Ensure junit_01.xml unmarshal returns a safe error

### DIFF
--- a/prow/external-plugins/verify-conformance-release/pkg/suite/suite.go
+++ b/prow/external-plugins/verify-conformance-release/pkg/suite/suite.go
@@ -507,7 +507,7 @@ func (s *PRSuite) GetJunitSubmittedConformanceTests() (tests []string, err error
 	}
 	testSuite := JunitTestSuite{}
 	if err := xml.Unmarshal([]byte(file.Contents), &testSuite); err != nil {
-		return []string{}, fmt.Errorf("unable to parse junit_01.xml file, %v", err)
+		return []string{}, common.SafeError(fmt.Errorf("unable to parse junit_01.xml file, %v", err))
 	}
 	for _, testcase := range testSuite.TestSuite {
 		if testcase.Skipped != nil {


### PR DESCRIPTION
A PR with a xml unmarshal error is printing raw HTML into a comment.

https://github.com/cncf/k8s-conformance/pull/1958#issuecomment-1144425645

This PR ensures that the error which may contain HTML is sanitised.